### PR TITLE
Add responsive weather UI with icons and color palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/ico.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>App</title>
+    <title>Weather App</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-hook-form": "^7.62.0",
+        "react-icons": "^5.5.0",
         "react-router-dom": "^7.8.1",
         "tailwindcss": "^4.1.12",
         "xlsx": "^0.18.5",
@@ -3113,6 +3114,15 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-refresh": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-hook-form": "^7.62.0",
+    "react-icons": "^5.5.0",
     "react-router-dom": "^7.8.1",
     "tailwindcss": "^4.1.12",
     "xlsx": "^0.18.5",

--- a/src/WeatherApp.jsx
+++ b/src/WeatherApp.jsx
@@ -1,0 +1,31 @@
+import { WiDaySunny, WiRain, WiCloud } from "react-icons/wi";
+import WeatherCard from "./components/WeatherCard";
+
+const forecast = [
+  { day: "Hoy", Icon: WiDaySunny, temp: 25, condition: "Soleado" },
+  { day: "Mañana", Icon: WiCloud, temp: 20, condition: "Nublado" },
+  { day: "Miércoles", Icon: WiRain, temp: 18, condition: "Lluvioso" },
+];
+
+export default function WeatherApp() {
+  return (
+    <div className="min-h-screen flex flex-col items-center p-4 bg-gradient-to-br from-sky-400 to-blue-700 text-white">
+      <header className="w-full max-w-4xl text-center mb-8">
+        <h1 className="text-4xl font-bold">Weather App</h1>
+        <p className="text-lg">Pronóstico rápido y claro</p>
+      </header>
+
+      <main className="w-full max-w-4xl grid grid-cols-1 sm:grid-cols-3 gap-4">
+        {forecast.map(({ day, Icon, temp, condition }) => (
+          <WeatherCard key={day} day={day} Icon={Icon} temp={temp} condition={condition} />
+        ))}
+      </main>
+
+      <nav className="w-full max-w-4xl mt-10 flex flex-col sm:flex-row justify-center sm:justify-between items-center gap-4">
+        <a href="#" className="hover:underline">Inicio</a>
+        <a href="#" className="hover:underline">Pronóstico</a>
+        <a href="#" className="hover:underline">Ajustes</a>
+      </nav>
+    </div>
+  );
+}

--- a/src/components/WeatherCard.jsx
+++ b/src/components/WeatherCard.jsx
@@ -1,0 +1,12 @@
+export default function WeatherCard(props) {
+  const { day, Icon: IconComponent, temp, condition } = props;
+
+  return (
+    <div className="bg-white/20 rounded-lg p-4 flex flex-col items-center">
+      <IconComponent className="text-6xl mb-2" />
+      <h2 className="text-xl font-semibold">{day}</h2>
+      <p className="text-3xl font-bold">{temp}°</p>
+      <p className="text-sm">{condition}</p>
+    </div>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,10 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
-import App from './App.jsx'
+import WeatherApp from './WeatherApp.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <WeatherApp />
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- add weather-themed landing page with gradient background and forecast cards
- show weather icons using react-icons and responsive grid layout
- render new WeatherApp component as app entry point

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: react-refresh/only-export-components in existing files)*
- `npx eslint src/WeatherApp.jsx src/components/WeatherCard.jsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a3e093f144832f8db2a077600fd3d8